### PR TITLE
Move Pagination, split PokemonMap

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,12 +6,14 @@ import CardList from './components/CardList';
 import Header from './components/Header';
 
 import 'bootstrap/dist/css/bootstrap.min.css';
+import PaginationNew from './components/PaginationNew';
 
 const App = () => (
   <Provider store={store}>
     <Container>
       <Header name="Pokemon List" />
       <CardList />
+      <PaginationNew />
     </Container>
   </Provider>
 );

--- a/src/components/CardList.js
+++ b/src/components/CardList.js
@@ -4,36 +4,20 @@ import PropTypes from 'prop-types';
 import { CardDeck } from 'reactstrap';
 import { getPokemon, getPokemonHasErrored, getPokemonIsLoading } from '../actions/pokemonActions';
 import CardNew from './CardNew';
-import PaginationNew from './PaginationNew';
 
 class CardList extends Component {
   componentDidMount() {
     this.props.getPokemon(1);
   }
 
-  shouldComponentUpdate(nextProps) {
-    if (this.props.pokemon === nextProps.pokemon) {
-      return false;
-    }
-    return true;
-  }
-
   render() {
     const { pokemon, error, errorMessage } = this.props;
     return (
-      <CardDeck
-        style={{
-          width: '100%',
-          display: 'flex',
-          justifyContent: 'center',
-        }}
-        className="mx-auto"
-      >
+      <CardDeck className="mx-auto d-flex justify-content-center">
         {error ? `Failed to fetch data: ${errorMessage}` : null}
         {pokemon.map(poke => (
           <CardNew key={poke.id} pokemon={poke} />
         ))}
-        {!error ? <PaginationNew /> : null}
       </CardDeck>
     );
   }

--- a/src/components/CardNew.js
+++ b/src/components/CardNew.js
@@ -3,7 +3,6 @@ import {
   Card, CardImg, CardBody, CardTitle, Row, Col,
 } from 'reactstrap';
 import PropTypes from 'prop-types';
-import { cardStyle } from '../helpers/styles';
 import PokemonMap from './PokemonMap';
 import PokemonInfo from './PokemonInfo';
 
@@ -24,7 +23,12 @@ class CardNew extends React.Component {
     return (
       <Row>
         <Col>
-          <Card body style={cardStyle} onClick={this.toggle}>
+          <Card
+            body
+            style={{ cursor: 'pointer' }}
+            className="d-flex align-items-center m-3"
+            onClick={this.toggle}
+          >
             <CardImg
               top
               width="100%"
@@ -33,12 +37,7 @@ class CardNew extends React.Component {
               style={{ height: '200px', width: '200px' }}
             />
             <CardBody style={{ paddingBottom: '0px', maxWidth: '210px' }}>
-              <CardTitle
-                style={{
-                  textAlign: 'center',
-                  marginBottom: '5px',
-                }}
-              >
+              <CardTitle className="text-center" style={{ marginBottom: '5px' }}>
                 <strong style={{ fontWeight: 600 }}>
                   #{pokemon.num} {pokemon.name}
                 </strong>

--- a/src/components/CardNew.js
+++ b/src/components/CardNew.js
@@ -3,7 +3,7 @@ import {
   Card, CardImg, CardBody, CardTitle, Row, Col,
 } from 'reactstrap';
 import PropTypes from 'prop-types';
-import PokemonMap from './PokemonMap';
+import PokemonType from './PokemonType';
 import PokemonInfo from './PokemonInfo';
 
 class CardNew extends React.Component {
@@ -43,7 +43,7 @@ class CardNew extends React.Component {
                 </strong>
               </CardTitle>
               <div className="text-center">
-                <PokemonMap variant={pokemon.type} groupBy="span" title="" />
+                <PokemonType variant={pokemon.type} groupBy="span" />
               </div>
               {open ? <PokemonInfo id={pokemon.id} open={open} toggle={this.toggle} /> : null}
             </CardBody>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Header = ({ name }) => (
-  <h1 className="display-3" style={{ textAlign: 'center' }} id="header">
+  <h1 className="display-3 text-center" id="header">
     {name}
   </h1>
 );

--- a/src/components/PaginationNew.js
+++ b/src/components/PaginationNew.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Pagination, PaginationItem, PaginationLink } from 'reactstrap';
+import {
+  Pagination, PaginationItem, PaginationLink, Row, Col,
+} from 'reactstrap';
 import PropTypes from 'prop-types';
 import { getPokemon } from '../actions/pokemonActions';
 import { getPages, changePageNumber } from '../actions/paginationActions';
@@ -53,26 +55,33 @@ class PaginationNew extends Component {
   render() {
     const { numberOfPages, currentPage } = this.props;
     return (
-      <Pagination>
-        <PaginationItem onClick={this.handlePrevious} disabled={currentPage === numberOfPages[0]}>
-          <PaginationLink previous href="#" />
-        </PaginationItem>
-        {numberOfPages
-          ? numberOfPages.map(page => (
-              <PaginationItem key={page} active={currentPage === page}>
-                <PaginationLink key={page} value={page} onClick={this.handleClick}>
-                  {page}
-                </PaginationLink>
-              </PaginationItem>
-          ))
-          : null}
-        <PaginationItem
-          onClick={this.handleNext}
-          disabled={currentPage === numberOfPages[numberOfPages.length - 1]}
-        >
-          <PaginationLink next href="#" />
-        </PaginationItem>
-      </Pagination>
+      <Row>
+        <Col>
+          <Pagination className="d-flex justify-content-center">
+            <PaginationItem
+              onClick={this.handlePrevious}
+              disabled={currentPage === numberOfPages[0]}
+            >
+              <PaginationLink previous href="#" />
+            </PaginationItem>
+            {numberOfPages
+              ? numberOfPages.map(page => (
+                  <PaginationItem key={page} active={currentPage === page}>
+                    <PaginationLink key={page} value={page} onClick={this.handleClick}>
+                      {page}
+                    </PaginationLink>
+                  </PaginationItem>
+              ))
+              : null}
+            <PaginationItem
+              onClick={this.handleNext}
+              disabled={currentPage === numberOfPages[numberOfPages.length - 1]}
+            >
+              <PaginationLink next href="#" />
+            </PaginationItem>
+          </Pagination>
+        </Col>
+      </Row>
     );
   }
 }

--- a/src/components/PokemonInfo.js
+++ b/src/components/PokemonInfo.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { getPokemonById } from '../actions/pokemonActions';
 import PokemonMap from './PokemonMap';
+import PokemonType from './PokemonType';
 
 class PokemonInfo extends React.Component {
   componentDidMount() {
@@ -60,7 +61,8 @@ class PokemonInfo extends React.Component {
                 <PokemonMap variant={pokemon.multipliers} title="Multipliers:" />
               </ul>
               <ul className="list-group">
-                <PokemonMap variant={pokemon.weaknesses} groupBy="li" title="Weaknesses:" />
+                <strong>Weaknesses:</strong>
+                <PokemonType variant={pokemon.weaknesses} groupBy="li" />
               </ul>
               <ul className="list-group">
                 <PokemonMap variant={pokemon.prev_evolution} title="Previous Evolution:" />

--- a/src/components/PokemonInfo.js
+++ b/src/components/PokemonInfo.js
@@ -12,13 +12,6 @@ class PokemonInfo extends React.Component {
     this.props.getPokemonById(this.props.id);
   }
 
-  shouldComponentUpdate(nextProps) {
-    if (this.props.pokemon.id === nextProps.pokemon.id) {
-      return false;
-    }
-    return true;
-  }
-
   listInfo = (pokemon) => {
     // chop up pokemon object to arrays with key : value pairs
     const pokemonEntries = Object.entries(pokemon);
@@ -27,14 +20,14 @@ class PokemonInfo extends React.Component {
       const pokemonInfoCut = pokemonEntries.slice(5, 13);
       // now map over k:v pairs and return JSX li tags. Also add styling
       const listedInfo = pokemonInfoCut.map(([key, value]) => (
-        <li key={key} className="list-group-item" style={{ textTransform: 'capitalize' }}>
+        <li key={key} className="list-group-item text-capitalize">
           {key.split('_').join(' ')}: <strong>{value}</strong>
         </li>
       ));
       return listedInfo;
     }
     return pokemonEntries.slice(5, 12).map(([key, value]) => (
-      <li key={key} className="list-group-item" style={{ textTransform: 'capitalize' }}>
+      <li key={key} className="list-group-item text-capitalize">
         {key.split('_').join(' ')}: <strong>{value}</strong>
       </li>
     ));

--- a/src/components/PokemonMap.js
+++ b/src/components/PokemonMap.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { typeColors, style } from '../helpers/styles';
 
-const PokemonMap = ({ variant, title, groupBy }) => (
+const PokemonMap = ({ variant, title }) => (
   <React.Fragment>
     {variant !== null && typeof variant !== 'undefined' ? (
       <React.Fragment>
@@ -28,46 +27,16 @@ const PokemonMap = ({ variant, title, groupBy }) => (
           </li>
       ))
       : null}
-    {groupBy === 'li' && typeof variant !== 'undefined'
-      ? variant.map(type => (
-          <li
-            key={type}
-            className="list-group-item"
-            style={{
-              backgroundColor: typeColors[type],
-              ...style,
-            }}
-          >
-            {type}
-          </li>
-      ))
-      : null}
-    {groupBy === 'span' && typeof variant !== 'undefined'
-      ? variant.map(type => (
-          <span
-            key={type}
-            className="d-inline text-center badge"
-            style={{
-              backgroundColor: typeColors[type],
-              ...style,
-            }}
-          >
-            {type}
-          </span>
-      ))
-      : null}
   </React.Fragment>
 );
 
 PokemonMap.defaultProps = {
   variant: undefined,
-  groupBy: undefined,
 };
 
 PokemonMap.propTypes = {
   variant: PropTypes.array,
   title: PropTypes.string.isRequired,
-  groupBy: PropTypes.string,
 };
 
 export default PokemonMap;

--- a/src/components/PokemonMap.test.js
+++ b/src/components/PokemonMap.test.js
@@ -12,11 +12,14 @@ test('PokemonMap renders provided data', () => {
   };
   const { getByText, container } = render(
     <Provider store={store}>
-      <PokemonMap variant={mockPokemon.type} groupBy="span" title="" />
+      <PokemonMap variant={mockPokemon.type} title="Multipliers" />
     </Provider>,
   );
   const typeSpan = getByText('red');
-  const allTypes = container.querySelectorAll('span');
+  const allTypes = container.querySelectorAll('li');
+  const headerTitle = getByText('Multipliers');
+
+  expect(headerTitle.textContent).toMatch('Multipliers');
   expect(allTypes.length).toBe(3);
   expect(typeSpan.textContent).toMatch('red');
 });

--- a/src/components/PokemonType.js
+++ b/src/components/PokemonType.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { typeColors, style } from '../helpers/styles';
+
+const PokemonType = ({ variant, groupBy }) => (
+  <React.Fragment>
+    {groupBy === 'li' && typeof variant !== 'undefined'
+      ? variant.map(type => (
+          <li
+            key={type}
+            className="list-group-item"
+            style={{
+              backgroundColor: typeColors[type],
+              ...style,
+            }}
+          >
+            {type}
+          </li>
+      ))
+      : null}
+    {groupBy === 'span'
+      ? variant.map(type => (
+          <span
+            key={type}
+            className="d-inline text-center badge"
+            style={{
+              backgroundColor: typeColors[type],
+              ...style,
+            }}
+          >
+            {type}
+          </span>
+      ))
+      : null}
+  </React.Fragment>
+);
+PokemonType.propTypes = {
+  variant: PropTypes.array.isRequired,
+  groupBy: PropTypes.string.isRequired,
+};
+
+export default PokemonType;

--- a/src/helpers/styles.js
+++ b/src/helpers/styles.js
@@ -24,11 +24,3 @@ export const style = {
   borderRadius: '5px',
   margin: '4px',
 };
-
-export const cardStyle = {
-  marginBottom: '15px',
-  marginTop: '15px',
-  display: 'flex',
-  alignItems: 'center',
-  cursor: 'pointer',
-};


### PR DESCRIPTION
Splitted `PokemonMap` functionality to 2 different components (like it was _before_, also I have naming things!)

Now, `PokemonType` serves purpose of purely rendering types and coloring them. It receives 2 different props: 

- variant => which here defaults to `pokemon.type`
- groupBy (span, li) => tells component to render _span or li_

---

`PokemonMap` now is used for evolutions (with img's) or multipliers. Also renders **text** provided in _title_ prop